### PR TITLE
Memory Leak

### DIFF
--- a/zad1/rentib.h
+++ b/zad1/rentib.h
@@ -27,8 +27,6 @@ int rentib_test(unsigned int seed) {
   srand(seed);
 
   for (n = 0; n < TESTS_NO; ++n) {
-    printf("%zu\n", n);
-
     for (i = 0; i < n; i++)
       q[i] = i;
 

--- a/zad2/basic_sync.c
+++ b/zad2/basic_sync.c
@@ -106,5 +106,9 @@ main(void)
   for (n = 0; n < N; ++n) thrd_join(thrd[n], NULL);
   for (n = 0; n < N; ++n) assert(params[n].res == res[n]);
 
+  free(thrd);
+  free(params);
+  free(res);
+
   return 0;
 }


### PR DESCRIPTION
W basic_sync nie jest zwalniana pamięć po zaalokowaniu, więc Valgrind krzyczy